### PR TITLE
faet : Implemented Global Query Filter for Inactive Entities

### DIFF
--- a/HRApplication.API/Controllers/EmployeeBasicInfoController.cs
+++ b/HRApplication.API/Controllers/EmployeeBasicInfoController.cs
@@ -55,7 +55,7 @@ public class EmployeeBasicInfoController : ControllerBase
     }
 
     [HttpGet]
-    [Route("GetEmployeeDetails")]
+    [Route("GetEmployeeDetailsById")]
     public async Task<ActionResult> GetEmployeeDetailsById(long _employeeId)
     {
         var request = new GetEmployeeBasicInfoDetailsByIdRequest { EmployeeId = _employeeId };

--- a/HRApplication.Persistence/HRApplicationDBContext.cs
+++ b/HRApplication.Persistence/HRApplicationDBContext.cs
@@ -3,6 +3,7 @@ using HRApplication.Domain.EmployeeManagement;
 using HRApplication.Domain.LeaveManagement;
 using HRApplication.Domain.MasterConfiguratio;
 using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
 
 namespace HRApplication.Persistence;
 
@@ -28,6 +29,19 @@ public class HRApplicationDBContext: DbContext
             modelBuilder.Entity(entityType.ClrType)
                 .Property("IntPrimaryId")
                 .ValueGeneratedOnAdd();
+
+            // Apply global query filter for IsDeleted property
+            if (entityType.ClrType.GetProperty("IsActive") != null)
+            {
+                var parameter = Expression.Parameter(entityType.ClrType, "e");
+                var property = Expression.Property(parameter, "IsActive");
+                var constant = Expression.Constant(true);
+                var body = Expression.Equal(property, constant);
+                var lambda = Expression.Lambda(body, parameter);
+
+                modelBuilder.Entity(entityType.ClrType)
+                    .HasQueryFilter(lambda);
+            }
         }
     }
 


### PR DESCRIPTION
In HR Application we have used the Soft Delete. I have added a feature that will apply the Filter "isActive= true" for every query. I have set it to the db context.